### PR TITLE
Issue26: import pyesapi error

### DIFF
--- a/pyesapi/__init__.py
+++ b/pyesapi/__init__.py
@@ -73,6 +73,7 @@ else:
     # clr.AddReference('System.Collections')
     clr.AddReference('VMS.TPS.Common.Model.API')
     # clr.AddReference('VMS.TPS.Common.Model')
+    clr.AddReference('VMS.TPS.Common.Model.Types')
 
     # the bad stuff
     import System

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='pyesapi',
-    version='0.2.5',
+    version='0.2.6',
     description='A customized Python interface to Eclipse Scripting API',
     long_description='Leverages the pythonnet project to interface with dotnet CLI to launch a stand-alone instance of ESAPI runtime. Helper functions and classes have been added to return numpy arrays and manage collections (of IEnumerable).',
     author='Michael M. Folkerts',


### PR DESCRIPTION
Related to #26, adding a reference to VMS.TPS.Common.Model.Types solves the error